### PR TITLE
fix: ignore warning

### DIFF
--- a/src/component/Main/ScriptBoardPreview.jsx
+++ b/src/component/Main/ScriptBoardPreview.jsx
@@ -28,6 +28,7 @@ const ScriptBoardPreview = () => {
         console.error("Error fetching script previews:", error);
       }
     );
+    // eslint-disable-next-line
   }, []);
 
   return (


### PR DESCRIPTION
- ESLint 는 의존성 배열이 빈 경우 경고를 출력합니다.
- 무한루프를 만들지 않으면서 경고가 뜨지 않게 하는 방법을 찾지 못해 일단 경고를 무시합니다.