### PR TITLE
fix: 산 넘어 산이네ㅋ delete api call path variable 수정

### DIFF
--- a/src/component/ScriptBoard/ScriptBoardContent.jsx
+++ b/src/component/ScriptBoard/ScriptBoardContent.jsx
@@ -64,7 +64,7 @@ const ScriptBoardContent = () => {
     try {
       const response = await apiCall(
         "GET",
-        `https://api.42box.kr/board-service/script-boards/${postId}`
+        `https://api.42box.kr/board-service/script-boards/${postId}`,
       );
       setPostInfo(response.data);
       if (response?.data?.scriptSaved)
@@ -95,7 +95,7 @@ const ScriptBoardContent = () => {
           name: postInfo?.scriptName,
           description: postInfo?.content,
           path: postInfo?.scriptPath,
-        }
+        },
       );
       const { savedId, name, description, path, userUuid } = response.data;
       window?.webkit?.messageHandlers?.downloadScript?.postMessage(
@@ -105,7 +105,7 @@ const ScriptBoardContent = () => {
           description: description,
           path: path,
           userUuid: userUuid,
-        })
+        }),
       );
       setUserScriptSavedId(savedId);
       successAlert.openAlert({
@@ -122,7 +122,7 @@ const ScriptBoardContent = () => {
     try {
       await apiCall(
         "DELETE",
-        `https://api.42box.kr/user-service/users/me/scripts/${postInfo?.myScriptId}`
+        `https://api.42box.kr/user-service/users/me/scripts/${userScriptSavedId}`,
       );
       successAlert.openAlert({
         title: "파일을 삭제했습니다!",
@@ -182,7 +182,7 @@ const ScriptBoardContent = () => {
                     description: postInfo?.content,
                     path: postInfo?.scriptPath,
                     userUuid: postInfo?.userUuid,
-                  })
+                  }),
                 );
               }}
             >


### PR DESCRIPTION
지겹네
예전: 페이지 첫 렌더링시 받아놓은 savedId를(페이지 처음 왔을 때는 해당 데이터가 없을 수도 있음) 자꾸 보내는데
지금: 파일을 저장했을 때 백이 넣는 값을 받아서 보냅니다