### PR TITLE
fix(ScriptBoard): change queryParams value check

### DIFF
--- a/src/component/ScriptBoard/ScriptBoard.jsx
+++ b/src/component/ScriptBoard/ScriptBoard.jsx
@@ -14,11 +14,10 @@ import SearchFilterSort from "../Util/SearchFilterSort";
 const ScriptBoard = () => {
   const loginStateValue = useRecoilValue(loginState);
   const searchBarStateValue = useRecoilValue(searchBarState);
-
   const [queryParams] = useSearchParams();
 
   const [viewOption, setViewOption] = useState(
-    queryParams.size === 0
+    queryParams.toString() === ""
       ? {
           page: 0,
           size: 5,


### PR DESCRIPTION
잘못된 쿼리파라미터 체크 로직을 수정하였습니다.
삼항연산자에서 true로 들어가지 않아서 빈 queryParams 객체가 viewOption 객체를 세팅하여 나타난 문제였습니다.